### PR TITLE
fix(lyform): not changing when input is of type bool

### DIFF
--- a/packages/lyform/lib/src/input/input_bloc.dart
+++ b/packages/lyform/lib/src/input/input_bloc.dart
@@ -22,7 +22,7 @@ class InputBloc<T> extends Bloc<InputBlocEvent<T>, InputBlocState<T>> {
       emit(InputBlocState<T>(event.value, null, debugName));
     });
     on<InputBlocEvent<T>>((event, emit) {
-      if (event.value == pureValue) {
+      if (event.value == pureValue && event.value is! bool) {
         return;
       }
       if (event is DirectValueEvent<T>) {


### PR DESCRIPTION
When the `InputBloc` is of type `bool`, its value is only possible to change only the first time, when you try to change it one more time it no longer allows it.